### PR TITLE
fixed issue with singleton flies in multi-fly assay for reassign identities

### DIFF
--- a/MATLAB/reassign_identities/assign_chambers.m
+++ b/MATLAB/reassign_identities/assign_chambers.m
@@ -103,7 +103,7 @@ nums = [1:nflies * nchambers];
 individuals = transpose(reshape(nums, [nflies, nchambers]));
 for i = 1:numel(occupied_chambers)
     
-    id_new(chambers == occupied_chambers(i)) = individuals(occupied_chambers(i), :);
+    id_new(chambers == occupied_chambers(i)) = individuals(occupied_chambers(i), 1:size(id_new(chambers == occupied_chambers(i)),2));
     
 end
 end


### PR DESCRIPTION
This should fix issues with identity reassignment when there are chambers with singleton flies in an otherwise multi-fly per chamber assay.  Skips missing identities. Only tested on one video.