### PR TITLE
Fix valid chambers

### DIFF
--- a/MATLAB/reassign_identities/assign_chambers.m
+++ b/MATLAB/reassign_identities/assign_chambers.m
@@ -21,6 +21,7 @@ startdir = pwd;
 cd(inputdir);
 % calibfile=strcat(inputdir,'-calibration.mat');
 calibfile = '../calibration.mat';
+calibfile_new = strrep(calibfile,'.mat', '_id_corrected.mat');
 JAABAfolder = strcat(inputdir, '_JAABA');
 trxfile = fullfile(JAABAfolder, 'trx.mat');
 trxfile_new = strrep(trxfile, '.mat', '_id_corrected.mat');
@@ -67,6 +68,16 @@ firstx = cellfun(@(f) f(1, 1), x);
 
 chambers = arrayfun(@(f) assign_one(f, maxy_chambers, miny_chambers, maxx_chambers, minx_chambers, numchambers), trx);
 startpos = left_right_assign(chambers, firstx, numchambers);
+valid_chambers = calib.valid_chambers;
+
+for i = 1:length(valid_chambers)
+    if ismember(i,chambers)
+        valid_chambers(i) = 1;
+    else valid_chambers(i) = 0;
+    end
+end
+
+calib.valid_chambers = valid_chambers;
 
 
 id_new = assign_identity(chambers, calib.n_flies, numchambers);
@@ -80,6 +91,7 @@ trx = nestedSortStruct(trx, 'id');
 ids = struct('id_old', id_old, 'id_new', id_new, 'chambers', chambers);
 save('ids', 'ids');
 save(trxfile_new, 'trx');
+save(calibfile_new, 'calib');
 
 cd(startdir);
 clear all;

--- a/MATLAB/reassign_identities/assign_chambers.m
+++ b/MATLAB/reassign_identities/assign_chambers.m
@@ -92,7 +92,9 @@ ids = struct('id_old', id_old, 'id_new', id_new, 'chambers', chambers);
 save('ids', 'ids');
 save(trxfile_new, 'trx');
 save(calibfile_new, 'calib');
-
+calibfilename_old = strrep(calibfile, '.mat', '_old.mat');
+movefile(calibfile, calibfilename_old);
+copyfile(calibfile_new, calibfile);
 cd(startdir);
 clear all;
 end

--- a/MATLAB/script_reassign_identities.m
+++ b/MATLAB/script_reassign_identities.m
@@ -28,6 +28,9 @@ movefile([OutputDirectory '/' FileName '/' FileName '/' FileName '-track_old.mat
          [OutputDirectory '/' FileName '/Backups/' FileName '-track--backup_3_pre_reassign_identities.mat']);
 movefile([OutputDirectory '/' FileName '/' FileName '/' FileName '-feat_old.mat'], ...
          [OutputDirectory '/' FileName '/Backups/' FileName '-feat--backup_3_pre_reassign_identities.mat']);
+movefile([OutputDirectory '/' FileName  '/calibration_old.mat'], ...
+         [OutputDirectory '/' FileName '/Backups/calibration--backup_3_pre_reassign_identities.mat']);
+delete([OutputDirectory '/' FileName '/calibration_id_corrected.mat']);
 delete([OutputDirectory '/' FileName '/' FileName '/' FileName '-track_id_corrected.mat']);
 delete([OutputDirectory '/' FileName '/' FileName '/' FileName '-feat_id_corrected.mat']);
 


### PR DESCRIPTION
Fixes the valid_chambers variable in the calibration file during identity reassignment. Works on test video where it was previously wrong.